### PR TITLE
added host variable to liquid

### DIFF
--- a/lib/locomotive/steam/middlewares/renderer.rb
+++ b/lib/locomotive/steam/middlewares/renderer.rb
@@ -107,6 +107,7 @@ module Locomotive::Steam
           'referer'     => request.referer,
           'url'         => request.url,
           'user_agent'  => request.user_agent,
+          'host'        => request.host
         }
       end
 


### PR DESCRIPTION
The base url variable returns the port, therefore breaking the usability of canonical tags. We need to restore {{ host }} liquid variable functionality to make canonical tags work again.